### PR TITLE
Update SQLAlchemy dependency to 2.0.25

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ flask-restful = "0.3.9"
 importlib-metadata = "6.0.0"
 importlib-resources = "5.10.0"
 pytest = "7.2.0"
-sqlalchemy = "2.5.1"
+sqlalchemy = "2.0.25"
 flask-bcrypt = "1.0.1"
 
 [dev-packages]


### PR DESCRIPTION
Updating the version of SQLAlchemy from 2.5.1 to 2.0.25.  

When running pipenv install, the installation will halt stating 2.5.1 is not a valid version and prints a list of valid versions.  2.0.25 being the lastest.

After the version change the installation was successful and I was able to complete the lab without issue.  

2.5.1 is a version of flash-sqlalchemy, but not sqlalchemy.